### PR TITLE
Support private AzureDevOps uri's

### DIFF
--- a/source/dotnet-pr.tests/ToolTests.cs
+++ b/source/dotnet-pr.tests/ToolTests.cs
@@ -14,26 +14,44 @@ namespace dotnet_pr.tests
         {
             _testOutputHelper = testOutputHelper;
         }
-        
-        [Theory]
-        [InlineData("git@ssh.dev.azure.com:v3/{0}/{1}/{2}")]
-        [InlineData("https://{0}@dev.azure.com/{0}/{1}/_git/{2}")]
-        public void AzureDevOpsTests(string remoteUrl)
+
+        private void TestAzureDevops(string remoteUrl, string expectedUrl, IPRTool tool)
         {
-            var tool = new AzureDevOps();
             var org = "someorg";
             var proj = "someproj";
             var repo = "somerepo";
-            var remoteUrlFormatted = string.Format(remoteUrl,org, proj, repo);
+            var remoteUrlFormatted = string.Format(remoteUrl, org, proj, repo);
+
             var context = new GitContext
             {
                 RemoteUrl = remoteUrlFormatted,
                 SourceBranch = "feature",
                 TargetBranch = "master"
             };
+
+            Assert.True(tool.IsMatch(remoteUrlFormatted));
+
             var prUrl = tool.BuildUrl(context);
+
             _testOutputHelper.WriteLine($"{remoteUrlFormatted} => {prUrl}");
-            Assert.Equal("https://dev.azure.com/someorg/someproj/_git/somerepo/pullrequestcreate?targetRef=master&sourceRef=feature", prUrl);
+
+            Assert.Equal(expectedUrl, prUrl);
+        }
+
+        [Theory]
+        [InlineData("git@ssh.dev.azure.com:v3/{0}/{1}/{2}")]
+        [InlineData("https://{0}@dev.azure.com/{0}/{1}/_git/{2}")]
+        public void AzureDevOpsPublicTests(string remoteUrl)
+        {
+            TestAzureDevops(remoteUrl, "https://dev.azure.com/someorg/someproj/_git/somerepo/pullrequestcreate?targetRef=master&sourceRef=feature", new AzureDevOps());
+        }
+
+        [Theory]
+        [InlineData("https://{0}.visualstudio.com/DefaultCollection/{1}/_git/{2}")]
+        [InlineData("{0}@vs-ssh.visualstudio.com:v3/{0}/{1}/{2}")]
+        public void AzureDevOpsPrivateTests(string remoteUrl)
+        {
+            TestAzureDevops(remoteUrl, "https://someorg.visualstudio.com/someproj/_git/somerepo/pullrequestcreate?targetRef=master&sourceRef=feature", new AzureDevOpsPrivate());
         }
     }
 }

--- a/source/dotnet-pr/PRTools/AzureDevOps.cs
+++ b/source/dotnet-pr/PRTools/AzureDevOps.cs
@@ -1,64 +1,20 @@
 namespace PR.PRTools
 {
-    public class AzureDevOps : IPRTool
+    public class AzureDevOps : AzureDevOpsBase
     {
-        /// <param name="remoteUrl">
-        /// https://RetireNET@dev.azure.com/RetireNET/dotnet-retire/_git/testrepo
-        /// git@ssh.dev.azure.com:v3/RetireNET/dotnet-retire/testrepo
-        /// </param>
-        public bool IsMatch(string remoteUrl)
+        protected override string Host => "dev.azure.com";
+
+        protected override string SshUrlFormat => "git@ssh";
+
+        protected override string BuildUrl(string org, string project, string repo, GitContext gitContext)
         {
-            return remoteUrl.Contains("dev.azure.com");
+            return $"https://dev.azure.com/{org}/{project}/_git/{repo}/pullrequestcreate?targetRef={gitContext.TargetBranch}&sourceRef={gitContext.SourceBranch}";
         }
 
-        public string BuildUrl(GitContext gitContext)
+        protected override string GetOrganizationHttp(string gitRemoteUrl)
         {
-            if (gitContext.RemoteUrl.StartsWith("git@ssh"))
-            {
-                return $"https://dev.azure.com/{GetOrganization(gitContext.RemoteUrl)}/{GetProject(gitContext.RemoteUrl)}/_git/{GetRepo(gitContext.RemoteUrl)}/pullrequestcreate?targetRef={gitContext.TargetBranch}&sourceRef={gitContext.SourceBranch}";
-            }
-            return $"https://dev.azure.com/{GetOrganizationHttp(gitContext.RemoteUrl)}/{GetProjectHttp(gitContext.RemoteUrl)}/_git/{GetRepoHttp(gitContext.RemoteUrl)}/pullrequestcreate?targetRef={gitContext.TargetBranch}&sourceRef={gitContext.SourceBranch}";
-        }
-        
-        private string GetOrganizationHttp(string gitRemoteUrl)
-        {
-            var gitUrl = gitRemoteUrl.Split("dev.azure.com/")[1];
+            var gitUrl = gitRemoteUrl.Split(Host + "/")[1];
             var repo = gitUrl.Split('/')[0];
-            return repo;
-        }
-        
-        private string GetRepoHttp(string gitRemoteUrl)
-        {
-            var gitUrl = gitRemoteUrl.Split("dev.azure.com/")[1];
-            var repo = gitUrl.Split('/')[3].Replace(".git", "");
-            return repo;
-        }
-
-        private string GetOrganization(string gitRemoteUrl)
-        {
-            var gitUrl = gitRemoteUrl.Split(':')[1];
-            var repo = gitUrl.Split('/')[1];
-            return repo;
-        }
-        
-        private string GetProject(string gitRemoteUrl)
-        {
-            var gitUrl = gitRemoteUrl.Split(':')[1];
-            var project = gitUrl.Split('/')[2];
-            return project;
-        }
-
-        private string GetProjectHttp(string gitRemoteUrl)
-        {
-            var gitUrl = gitRemoteUrl.Split("dev.azure.com/")[1];
-            var repo = gitUrl.Split('/')[1];
-            return repo;
-        }
-
-        private string GetRepo(string gitRemoteUrl)
-        {
-            var gitUrl = gitRemoteUrl.Split(':')[1];
-            var repo = gitUrl.Split('/')[3].Replace(".git", "");
             return repo;
         }
     }

--- a/source/dotnet-pr/PRTools/AzureDevOpsBase.cs
+++ b/source/dotnet-pr/PRTools/AzureDevOpsBase.cs
@@ -1,0 +1,74 @@
+﻿namespace PR.PRTools
+{
+    public abstract class AzureDevOpsBase : IPRTool
+    {
+        protected abstract string Host { get; }
+        protected abstract string SshUrlFormat { get; }
+
+        public bool IsMatch(string remoteUrl)
+        {
+            return remoteUrl.Contains(Host);
+        }
+
+        public string BuildUrl(GitContext gitContext)
+        {
+            string org;
+            string project;
+            string repo;
+
+            if (gitContext.RemoteUrl.Contains(SshUrlFormat))
+            {
+                org = GetOrganization(gitContext.RemoteUrl);
+                project = GetProject(gitContext.RemoteUrl);
+                repo = GetRepo(gitContext.RemoteUrl);
+            }
+            else
+            {
+                org = GetOrganizationHttp(gitContext.RemoteUrl);
+                project = GetProjectHttp(gitContext.RemoteUrl);
+                repo = GetRepoHttp(gitContext.RemoteUrl);
+            }
+
+            return BuildUrl(org, project, repo, gitContext);
+        }
+
+        protected abstract string BuildUrl(string org, string project, string repo, GitContext gitContext);
+
+        protected abstract string GetOrganizationHttp(string gitRemoteUrl);
+
+        private string GetOrganization(string gitRemoteUrl)
+        {
+            var gitUrl = gitRemoteUrl.Split(':')[1];
+            var org = gitUrl.Split('/')[1];
+            return org;
+        }
+
+        private string GetProjectHttp(string gitRemoteUrl)
+        {
+            var gitUrl = gitRemoteUrl.Split(Host + "/")[1];
+            var project = gitUrl.Split('/')[1];
+            return project;
+        }
+
+        private string GetProject(string gitRemoteUrl)
+        {
+            var gitUrl = gitRemoteUrl.Split(':')[1];
+            var project = gitUrl.Split('/')[2];
+            return project;
+        }
+
+        private string GetRepoHttp(string gitRemoteUrl)
+        {
+            var gitUrl = gitRemoteUrl.Split(Host + "/")[1];
+            var repo = gitUrl.Split('/')[3].Replace(".git", "");
+            return repo;
+        }
+
+        private string GetRepo(string gitRemoteUrl)
+        {
+            var gitUrl = gitRemoteUrl.Split(':')[1];
+            var repo = gitUrl.Split('/')[3].Replace(".git", "");
+            return repo;
+        }
+    }
+}

--- a/source/dotnet-pr/PRTools/AzureDevOpsPrivate.cs
+++ b/source/dotnet-pr/PRTools/AzureDevOpsPrivate.cs
@@ -1,0 +1,24 @@
+namespace PR.PRTools
+{
+    public class AzureDevOpsPrivate : AzureDevOpsBase
+    {
+        protected override string Host => ".visualstudio.com";
+
+        protected override string SshUrlFormat => "@vs-ssh.visualstudio.com";
+
+        protected override string BuildUrl(string org, string project, string repo, GitContext gitContext)
+        {
+            return $"https://{org}.visualstudio.com/{project}/_git/{repo}/pullrequestcreate?targetRef={gitContext.TargetBranch}&sourceRef={gitContext.SourceBranch}";
+        }
+
+        protected override string GetOrganizationHttp(string gitRemoteUrl)
+        {
+            const string scheme = "://";
+            var schemeIdx = gitRemoteUrl.IndexOf(scheme);
+            var gitRemoteUrlWithoutScheme = gitRemoteUrl.Substring(schemeIdx + scheme.Length);
+            var orgIdx = gitRemoteUrlWithoutScheme.IndexOf('.');
+            var org = gitRemoteUrlWithoutScheme.Substring(0, orgIdx);
+            return org;
+        }
+    }
+}

--- a/source/dotnet-pr/Program.cs
+++ b/source/dotnet-pr/Program.cs
@@ -49,7 +49,7 @@ namespace PR
                 .AddLogging(c =>
                 {
                     c.AddConsole().AddDebug();
-                    
+
                     if (debugOptions.EnableDebug)
                     {
                         c.SetMinimumLevel(LogLevel.Trace);
@@ -58,16 +58,17 @@ namespace PR
                     {
                         c.SetMinimumLevel(LogLevel.Warning);
                     }
-                    
+
                 })
                 .AddSingleton(debugOptions)
                 .AddSingleton<GitRepositoryLocator>()
                 .AddSingleton<GitRemoteGuesser>()
-                .AddSingleton<IPRTool,BitBucketSelfHosted>()
-                .AddSingleton<IPRTool,GitHub>()
-                .AddSingleton<IPRTool,BitBucketOrg>()
-                .AddSingleton<IPRTool,Gitlab>()
-                .AddSingleton<IPRTool,AzureDevOps>()
+                .AddSingleton<IPRTool, BitBucketSelfHosted>()
+                .AddSingleton<IPRTool, GitHub>()
+                .AddSingleton<IPRTool, BitBucketOrg>()
+                .AddSingleton<IPRTool, Gitlab>()
+                .AddSingleton<IPRTool, AzureDevOps>()
+                .AddSingleton<IPRTool, AzureDevOpsPrivate>()
                 .AddSingleton<Browser>()
                 .AddSingleton<Application>();
 


### PR DESCRIPTION
Private DevOps url's have a different format, this PR allows those to work as well.

I opted to keep one DevOps class, but it seemed cleaner to split them up as both input and output differ greatly.